### PR TITLE
Cleans server data directory on build (cross-platform compatibility)

### DIFF
--- a/RoRebuildServer/RoRebuildServer/RoRebuildServer.csproj
+++ b/RoRebuildServer/RoRebuildServer/RoRebuildServer.csproj
@@ -75,9 +75,9 @@
     <Folder Include="Simulation\Items\ItemHandlers\" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="@echo Clearing server script files -^&gt; &quot;$(TargetDir)ServerData&quot;&#xD;&#xA;rmdir /s /q &quot;$(TargetDir)ServerData&quot;" />
+  <Target Name="CleanServerData" BeforeTargets="PreBuildEvent">
+    <Message Text="Clearing server script files -> $(OutputPath)ServerData" Importance="high" />
+    <RemoveDir Directories="$(OutputPath)ServerData" />
+    <MakeDir Directories="$(OutputPath)ServerData" />
   </Target>
-
-
 </Project>

--- a/RoRebuildServer/RoRebuildServer/RoRebuildServer.csproj
+++ b/RoRebuildServer/RoRebuildServer/RoRebuildServer.csproj
@@ -78,6 +78,5 @@
   <Target Name="CleanServerData" BeforeTargets="PreBuildEvent">
     <Message Text="Clearing server script files -> $(OutputPath)ServerData" Importance="high" />
     <RemoveDir Directories="$(OutputPath)ServerData" />
-    <MakeDir Directories="$(OutputPath)ServerData" />
   </Target>
 </Project>


### PR DESCRIPTION
Refactors the pre-build process to reliably clean the server data directory.

This ensures a clean slate for each build by removing the directory before copying new script files. Uses `RemoveDir` and `MakeDir` tasks for improved reliability and **cross-platform compatibility**.