### PR TITLE
Automatically loading emote sprite data into the emote menu button prefab + Map Loading error catching

### DIFF
--- a/RebuildClient/Assets/Prefabs/MainUI/Emotes.prefab
+++ b/RebuildClient/Assets/Prefabs/MainUI/Emotes.prefab
@@ -696,7 +696,7 @@ MonoBehaviour:
   m_Content: {fileID: 5944660909039314450}
   m_Horizontal: 0
   m_Vertical: 1
-  m_MovementType: 1
+  m_MovementType: 2
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
@@ -1305,6 +1305,7 @@ MonoBehaviour:
   AutomaticallyFitIntoPlayArea: 1
   ContentArea: {fileID: 3638620482084932526}
   EntryTemplate: {fileID: 7800933896615605917}
+  EmoteRenderer: {fileID: 5017541219376389207}
 --- !u!114 &1300374924258180238
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokMapImporterWindow.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokMapImporterWindow.cs
@@ -36,6 +36,7 @@ namespace Assets.Scripts.MapEditor.Editor
                 Directory.CreateDirectory("Assets/Scenes/Maps/");
 
             int imported = 0;
+            List<string> failedMaps = new List<string>();
             foreach (var map in maps)
             {
                 var scenePath = $"Assets/Scenes/Maps/{map.Code}.unity";
@@ -45,19 +46,39 @@ namespace Assets.Scripts.MapEditor.Editor
                 var gndPath = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, map.Code + ".gnd");
                 if (File.Exists(gndPath))
                 {
-                    ImportMap(gndPath);
-                    imported++;
+                    try
+                    {
+                        ImportMap(gndPath);
+                        imported++;
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"Exception generated while importing map {gndPath}!");
+                        Debug.LogException(e);
+                        failedMaps.Add("Import Error - " + gndPath);
+                    }
                 }
                 else
                 {
                     Debug.LogWarning($"Map file not found: {gndPath}");
+                    failedMaps.Add("Map File not found - " + gndPath);
                 }
             }
 
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
 
-            Debug.Log($"[Map Import] Imported {imported} new map(s).");
+            Debug.Log($"[Map Import] Imported {imported} new map(s). Import failed for {failedMaps.Count} Map(s)");
+
+            if (failedMaps.Count > 0)
+            {
+                string failedMapsList = "";
+                foreach (string map in failedMaps)
+                {
+                    failedMapsList += map + "\n";
+                }
+                Debug.LogWarning($"[Map Import] Map import failed on: \n{failedMapsList}");
+            }
         }
 
 

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
@@ -213,7 +213,7 @@ namespace Assets.Scripts.MapEditor.Editor
                             color = "purple";
                             break;
                         default:
-                            throw new Exception("Unknown cell type: " + map.name + "(X: " + x + " / Y: " + y + ") " + type + ", Likely result of an incompatible map version. Stopping map import process.");
+                            throw new Exception("Unknown cell type for Map " + map.name + " (X: " + x + " / Y: " + y + ") Value " + type");
                     }
 
                     if (isInWater)

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
@@ -213,7 +213,7 @@ namespace Assets.Scripts.MapEditor.Editor
                             color = "purple";
                             break;
                         default:
-                            throw new Exception("Unknown cell type " + type);
+                            throw new Exception("Unknown cell type: " + map.name + "(X: " + x + " / Y: " + y + ") " + type + ", Likely result of an incompatible map version. Stopping map import process.");
                     }
 
                     if (isInWater)

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
@@ -213,7 +213,7 @@ namespace Assets.Scripts.MapEditor.Editor
                             color = "purple";
                             break;
                         default:
-                            throw new Exception("Unknown cell type for Map " + map.name + " (X: " + x + " / Y: " + y + ") Value " + type");
+                            throw new Exception("Unknown cell type for Map " + map.name + " (X: " + x + " / Y: " + y + ") Value " + type);
                     }
 
                     if (isInWater)

--- a/RebuildClient/Assets/Scripts/UI/EmoteWindow.cs
+++ b/RebuildClient/Assets/Scripts/UI/EmoteWindow.cs
@@ -1,9 +1,11 @@
-using System.Collections.Generic;
-using System.Linq;
 using Assets.Scripts.Sprites;
 using PlayerControl;
 using RebuildSharedData.ClientTypes;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 
 namespace Assets.Scripts.UI
 {
@@ -11,6 +13,7 @@ namespace Assets.Scripts.UI
     {
         public GameObject ContentArea;
         public GameObject EntryTemplate;
+        public RoSpriteRendererUI EmoteRenderer;
         private bool isInitialized;
 
         private List<EmoteEntry> EmoteEntries = new();
@@ -82,28 +85,43 @@ namespace Assets.Scripts.UI
             return emote;
         }
 
+        private void OnLoadEmotesDone(UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationHandle<RoSpriteData> spriteData)
+        {
+            if (spriteData.Result != null)
+            {
+                EmoteRenderer.SpriteData = spriteData.Result;
+
+                var emotes = ClientDataLoader.Instance.GetEmoteTable;
+
+                foreach (var (_, emote) in emotes)
+                {
+                    var entry = CreateEntry(emote);
+                    EmoteEntries.Add(entry);
+                }
+                //
+                // var text = EmoteListFile.text.Split("\r\n");
+                //
+                // for (var i = 1; i < text.Length; i++)
+                // {
+                //     var line = text[i];
+                //     var entry = CreateEntry(line);
+                //
+                //     EmoteEntries.Add(entry);
+                // }
+
+                Destroy(EntryTemplate);
+
+                isInitialized = true;
+            }
+            else
+            {
+                Debug.LogWarning("Emote Sprite Data could not be found at: Assets/Sprites/Imported/Miscss/emotionsas.asset");
+            }
+        }
+
         void Init()
         {
-            var emotes = ClientDataLoader.Instance.GetEmoteTable;
-            foreach (var (_, emote) in emotes)
-            {
-                var entry = CreateEntry(emote);
-                EmoteEntries.Add(entry);
-            }
-            //
-            // var text = EmoteListFile.text.Split("\r\n");
-            //
-            // for (var i = 1; i < text.Length; i++)
-            // {
-            //     var line = text[i];
-            //     var entry = CreateEntry(line);
-            //
-            //     EmoteEntries.Add(entry);
-            // }
-
-            Destroy(EntryTemplate);
-            
-            isInitialized = true;
+            Addressables.LoadAssetAsync<RoSpriteData>("Assets/Sprites/Misc/emotion.spr").Completed += OnLoadEmotesDone;
         }
 
         // Update is called once per frame


### PR DESCRIPTION
Automatically Loads emotes asset into emote menu button prefab via addressables, so the emote menu should work without manually assigning the asset in editor.
Also made the emote menu scroll non-elastic, since it just felt off in RO imo.

Accidentally also pushed the ImportAllMissingMaps with try-catch here to not cancel the whole importing process when encountering an incompatible map format.