### PR TITLE
fix build android error

### DIFF
--- a/RebuildClient/Assets/Scripts/Sprites/ClientDataLoader.cs
+++ b/RebuildClient/Assets/Scripts/Sprites/ClientDataLoader.cs
@@ -103,7 +103,7 @@ namespace Assets.Scripts.Sprites
             "ClientConfigGenerated/effects.json",
             "ClientConfigGenerated/levelchart.txt",
             "ClientConfig/AdminWarpList.txt",
-            "ClientConfig/fogdata.json",
+            "ClientConfig/fogData.json",
             MapDataPath,
         };
 
@@ -250,7 +250,7 @@ namespace Assets.Scripts.Sprites
                                  + " This can cause the file to be unloadable in a webGL build.");
 #endif
 
-#if !UNITY_WEBGL && !UNITY_EDITOR
+#if !UNITY_WEBGL && !UNITY_EDITOR && !UNITY_ANDROID
             //Non WebGL platforms can read from streaming assets directly.
             return File.ReadAllText(Path.Combine(Application.streamingAssetsPath, file));
 #endif

--- a/RebuildClient/Assets/Scripts/Utility/SceneTransitioner.cs
+++ b/RebuildClient/Assets/Scripts/Utility/SceneTransitioner.cs
@@ -201,7 +201,7 @@ namespace Assets.Scripts.Utility
 
 			if (mapFogInfo == null)
 			{
-				var json = JsonUtility.FromJson<Wrapper<FogInfo>>(ClientDataLoader.ReadStreamingAssetFile("ClientConfig/fogdata.json"));
+				var json = JsonUtility.FromJson<Wrapper<FogInfo>>(ClientDataLoader.ReadStreamingAssetFile("ClientConfig/fogData.json"));
 				mapFogInfo = json.Items.ToList();
 			}
 			


### PR DESCRIPTION
Fixed an issue with file name case sensitivity when building for Android.

Fixed an issue where `File.ReadAllText` could not be used on the Android platform.
