### PR TITLE
Fix client data import paths on case-sensitive filesystems (like Linux)

### DIFF
--- a/RebuildClient/Assets/Scripts/Editor/ActImporter.cs
+++ b/RebuildClient/Assets/Scripts/Editor/ActImporter.cs
@@ -14,6 +14,29 @@ public class ActImporter : ScriptedImporter
 {
     public int PaletteCount;
 
+    public static string ResolveSiblingFileCaseInsensitive(string expectedPath)
+    {
+        expectedPath = expectedPath.Replace("\\", "/");
+
+        if (File.Exists(expectedPath))
+            return expectedPath;
+
+        var dir = Path.GetDirectoryName(expectedPath);
+        var fileName = Path.GetFileName(expectedPath);
+
+        if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir))
+            return expectedPath;
+
+        foreach (var file in Directory.GetFiles(dir))
+        {
+            if (string.Equals(Path.GetFileName(file), fileName, StringComparison.OrdinalIgnoreCase))
+                return file.Replace("\\", "/");
+        }
+
+        return expectedPath;
+    }
+
+
     public override void OnImportAsset(AssetImportContext ctx)
     {
         // var asset = ScriptableObject.CreateInstance<RagnarokActFile>();
@@ -50,8 +73,9 @@ public class ActImporter : ScriptedImporter
         var asset = ScriptableObject.CreateInstance<RoSpriteData>();
         AssetDatabase.CreateAsset(asset, Path.Combine(targetFolder, $"{baseName}.asset"));
 
+        var spritePath = ResolveSiblingFileCaseInsensitive(Path.ChangeExtension(actPath, ".spr"));
         var loader = new RagnarokSpriteLoader();
-        loader.Load(actPath.Replace(".act", ".spr"), atlasPath, asset, null);
+        loader.Load(spritePath, atlasPath, asset, null);
         SetUpSpriteData(loader, asset, dir, baseName, baseName);
 
         for (var i = 0; i < palettes.Count; i++)
@@ -61,29 +85,32 @@ public class ActImporter : ScriptedImporter
 
             atlasPath = Path.Combine(targetFolder, "Atlas/", $"{baseName}_{i}_atlas.png").Replace("\\", "/");
             loader = new RagnarokSpriteLoader();
-            loader.Load(actPath.Replace(".act", ".spr"), atlasPath, asset, palettes[i]);
+            loader.Load(spritePath, atlasPath, asset, palettes[i]);
             SetUpSpriteData(loader, asset, dir, baseName, $"{baseName}_{i}");
         }
 
         AssetDatabase.SaveAssets();
     }
 
-    private static void SetUpSpriteData(RagnarokSpriteLoader spr, RoSpriteData asset, string basePath, string baseName, string outName)
+    private static void SetUpSpriteData(RagnarokSpriteLoader spriteLoader, RoSpriteData asset, string basePath, string baseName, string outputName)
     {
         var actName = Path.Combine(basePath, baseName + ".act");
-        var imfFile = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectorySafe, "imf/", baseName + ".imf");
-        if (!File.Exists(imfFile))
-            imfFile = null;
+        var dataDir = RagnarokDirectory.GetRagnarokDataDirectorySafe;
+        var imfPath = string.IsNullOrWhiteSpace(dataDir)
+            ? null
+            : Path.Combine(dataDir, "imf/", baseName + ".imf");
+        if (imfPath != null && !File.Exists(imfPath))
+            imfPath = null;
         
         var actLoader = new RagnarokActLoader();
-        var actions = actLoader.Load(spr, actName, imfFile);
+        var actions = actLoader.Load(spriteLoader, actName, imfPath);
 
         asset.Actions = actions.ToArray();
-        asset.Sprites = spr.Sprites.ToArray();
-        asset.SpriteSizes = spr.SpriteSizes.ToArray();
-        asset.Name = outName;
-        asset.Atlas = spr.Atlas;
-        asset.SpritesPerPalette = spr.SpriteFrameCount;
+        asset.Sprites = spriteLoader.Sprites.ToArray();
+        asset.SpriteSizes = spriteLoader.SpriteSizes.ToArray();
+        asset.Name = outputName;
+        asset.Atlas = spriteLoader.Atlas;
+        asset.SpritesPerPalette = spriteLoader.SpriteFrameCount;
 
         if (actLoader.Sounds != null)
         {
@@ -238,13 +265,13 @@ public class ActPostProcessor : AssetPostprocessor
     {
         foreach (var importedAsset in importedAssets)
         {
-            if (!importedAsset.EndsWith(".act"))
+            if (!importedAsset.EndsWith(".act", StringComparison.OrdinalIgnoreCase))
                 continue;
             
-            var sprName = Path.Combine(Path.GetDirectoryName(importedAsset), Path.GetFileNameWithoutExtension(importedAsset) + ".spr");
-            if (!File.Exists(sprName))
+            var spritePath = ActImporter.ResolveSiblingFileCaseInsensitive(Path.Combine(Path.GetDirectoryName(importedAsset), Path.GetFileNameWithoutExtension(importedAsset) + ".spr"));
+            if (!File.Exists(spritePath))
             {
-                Debug.LogError($"Could not load sprite {importedAsset} as it did not have an associated .spr sprite data file.");
+                Debug.LogError($"Could not load sprite {importedAsset} as it did not have an associated .spr/.Spr sprite data file.");
                 continue;
             }
 

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokDirectory.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokDirectory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -7,12 +7,27 @@ namespace Assets.Scripts.MapEditor.Editor
 {
     class RagnarokDirectory : EditorWindow
     {
+        private static string NormalizeDataPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            try
+            {
+                return Path.GetFullPath(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public static string GetRagnarokDataDirectory
         {
             get
             {
-                var path = EditorPrefs.GetString("RagnarokDataPath", null);
-                if(path == null)
+                var path = NormalizeDataPath(EditorPrefs.GetString("RagnarokDataPath", null));
+                if (path == null)
                     throw new Exception("You must set a ragnarok data directory first!");
                 return path;
             }
@@ -23,8 +38,7 @@ namespace Assets.Scripts.MapEditor.Editor
         {
             get
             {
-                var path = EditorPrefs.GetString("RagnarokDataPath", null);
-                return path;
+                return NormalizeDataPath(EditorPrefs.GetString("RagnarokDataPath", null));
             }
         }
 
@@ -32,16 +46,15 @@ namespace Assets.Scripts.MapEditor.Editor
         [MenuItem("Ragnarok/Set Ragnarok Data Directory", priority = 0)]
         public static void SetDataDirectory()
         {
-            var defaultName = "Data";
-            var oldPath = EditorPrefs.GetString("RagnarokDataPath", null);
-            if (!string.IsNullOrWhiteSpace(oldPath) && Directory.Exists(oldPath))
-            {
-                var di = new DirectoryInfo(oldPath);
-                oldPath = di.Parent.FullName;
-                defaultName = di.Name;
-            }
-            var path = EditorUtility.SaveFolderPanel("Locate Ragnarok Data Folder", oldPath, defaultName);
-            if (Directory.Exists(path))
+            var oldPath = NormalizeDataPath(EditorPrefs.GetString("RagnarokDataPath", null));
+            var startPath = oldPath;
+
+            if (string.IsNullOrWhiteSpace(startPath) || !Directory.Exists(startPath))
+                startPath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+            var path = NormalizeDataPath(EditorUtility.OpenFolderPanel("Locate Ragnarok Data Folder", startPath, ""));
+
+            if (!string.IsNullOrWhiteSpace(path) && Directory.Exists(path))
             {
                 EditorPrefs.SetString("RagnarokDataPath", path);
                 Debug.Log("Ragnarok data directory set to: " + path);

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokMapImporterWindow.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokMapImporterWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -482,7 +482,7 @@ namespace Assets.Scripts.MapEditor.Editor
                 entriesAdded.Add(entry);
             }
 
-            guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets/Maps/Minimap" });
+            guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets/Maps/minimap" });
 
             for (int i = 0; i < guids.Length; i++)
             {
@@ -564,7 +564,7 @@ namespace Assets.Scripts.MapEditor.Editor
             // walkData = altitude.SplitWalkData(walkData, 4, Path.GetFileNameWithoutExtension(importPath));
             walkData.name = Path.GetFileNameWithoutExtension(importPath) + "_walk";
 
-            var saveDir = "Assets/maps/altitude";
+            var saveDir = "Assets/Maps/altitude";
 
             if (!Directory.Exists(saveDir))
                 Directory.CreateDirectory(saveDir);
@@ -811,7 +811,7 @@ namespace Assets.Scripts.MapEditor.Editor
 
         static void ImportMap(string f)
         {
-            var saveDir = Path.Combine(Application.dataPath, "maps").Replace("\\", "/");
+            var saveDir = Path.Combine(Application.dataPath, "Maps").Replace("\\", "/");
 
             var lastDirectory = Path.GetDirectoryName(f);
             var baseName = Path.GetFileNameWithoutExtension(f);
@@ -857,14 +857,15 @@ namespace Assets.Scripts.MapEditor.Editor
 
                 foreach (var model in world.Models)
                 {
-                    var baseFolder = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, "model");
+                    var baseFolder = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, "model").Replace("\\", "/");
 
-                    var modelPath = Path.Combine(baseFolder, model.FileName);
+                    var normalizedModelFileName = model.FileName.Replace("\\", "/").TrimStart('/');
+                    var modelPath = Path.Combine(baseFolder, normalizedModelFileName).Replace("\\", "/");
                     var relative = DirectoryHelper.GetRelativeDirectory(baseFolder, Path.GetDirectoryName(modelPath));
-                    var mBaseName = Path.GetFileNameWithoutExtension(model.FileName);
+                    var modelBaseName = Path.GetFileNameWithoutExtension(normalizedModelFileName);
 
-                    var prefabFolder = Path.Combine("Assets/models/prefabs/", relative).Replace("\\", "/");
-                    var prefabPath = Path.Combine(prefabFolder, mBaseName + ".prefab").Replace("\\", "/");
+                    var prefabFolder = Path.Combine("Assets/Models/Prefabs/", relative).Replace("\\", "/");
+                    var prefabPath = Path.Combine(prefabFolder, modelBaseName + ".prefab").Replace("\\", "/");
 
                     if (!Directory.Exists(prefabFolder))
                         Directory.CreateDirectory(prefabFolder);
@@ -930,7 +931,7 @@ namespace Assets.Scripts.MapEditor.Editor
                 return;
 
             //var saveDir = EditorUtility.SaveFolderPanel("Save Folder", Application.dataPath, "");
-            var saveDir = Path.Combine(Application.dataPath, "maps").Replace("\\", "/");
+            var saveDir = Path.Combine(Application.dataPath, "Maps").Replace("\\", "/");
             //Debug.Log(saveDir);
 
             foreach (var f in files)

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokModelLoader.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokModelLoader.cs
@@ -126,7 +126,7 @@ namespace Assets.Scripts.MapEditor.Editor
 
 		public void LoadTextures(string savePath)
 		{
-			var path = Path.Combine("Assets/models/atlas", savePath); //Path.Combine(savePath);
+			var path = Path.Combine("Assets/Models/atlas", savePath); //Path.Combine(savePath);
 			if (!Directory.Exists(path))
 				Directory.CreateDirectory(path);
 
@@ -143,7 +143,7 @@ namespace Assets.Scripts.MapEditor.Editor
 				var tName = br.ReadKoreanString(40);
 				model.Textures.Add(tName);
 
-				var texout = TextureImportHelper.GetOrImportTextureToProject(tName, RagnarokDirectory.GetRagnarokDataDirectory, "Assets/models");
+				var texout = TextureImportHelper.GetOrImportTextureToProject(tName, RagnarokDirectory.GetRagnarokDataDirectory, "Assets/Models");
 				textures.Add(texout);
 			}
 
@@ -370,7 +370,7 @@ namespace Assets.Scripts.MapEditor.Editor
 			}
 
 			//save Mesh
-			var meshPath = AssetHelper.GetAssetPath(Path.Combine("Assets/models/mesh", savePath, baseName), Path.GetFileNameWithoutExtension(node.Name) + ".asset");
+			var meshPath = AssetHelper.GetAssetPath(Path.Combine("Assets/Models/mesh", savePath, baseName), Path.GetFileNameWithoutExtension(node.Name) + ".asset");
 
 			AssetDatabase.CreateAsset(mesh, meshPath);
 
@@ -397,7 +397,7 @@ namespace Assets.Scripts.MapEditor.Editor
 			mat.doubleSidedGI = true;
 			mat.enableInstancing = true;
 
-			var matPath = AssetHelper.GetAssetPath(Path.Combine("Assets/models/materials", savePath), Path.GetFileNameWithoutExtension(baseName) + ".mat");
+			var matPath = AssetHelper.GetAssetPath(Path.Combine("Assets/Models/materials", savePath), Path.GetFileNameWithoutExtension(baseName) + ".mat");
 
 			AssetDatabase.CreateAsset(mat, matPath);
 
@@ -568,7 +568,7 @@ namespace Assets.Scripts.MapEditor.Editor
 				//var modelName = @"splen\민가침대02.rsm";
 				var modelName = @"외부소품\트랩05.rsm";
 				
-				var modelPath = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, $@"model\{modelName}"); //prontera armory
+				var modelPath = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, "model", modelName).Replace("\\", "/"); //prontera armory
 				var savePath = DirectoryHelper.GetRelativeDirectory(RagnarokDirectory.GetRagnarokDataDirectory, Path.GetDirectoryName(modelPath));
 		
 				
@@ -614,7 +614,7 @@ namespace Assets.Scripts.MapEditor.Editor
 					//var modelName = @"외부소품\트랩01.rsm";
 					var modelName = trap.Key;
 
-					var modelPath = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, $@"model\{modelName}");
+					var modelPath = Path.Combine(RagnarokDirectory.GetRagnarokDataDirectory, "model", modelName).Replace("\\", "/");
 					var savePath = DirectoryHelper.GetRelativeDirectory(RagnarokDirectory.GetRagnarokDataDirectory, Path.GetDirectoryName(modelPath));
 
 					loader.LoadModel(modelPath, savePath);

--- a/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/Editor/RagnarokWalkableDataImporter.cs
@@ -94,20 +94,20 @@ namespace Assets.Scripts.MapEditor.Editor
             }
 
 
-            if (!Directory.Exists("Assets/maps/altitude/mapinfo"))
-                Directory.CreateDirectory("Assets/maps/altitude/mapinfo");
+            if (!Directory.Exists("Assets/Maps/altitude/mapinfo"))
+                Directory.CreateDirectory("Assets/Maps/altitude/mapinfo");
 
-            map.SaveCellDataToFile(cells, Path.Combine("Assets/maps/altitude/mapinfo", name + "_walk.bytes").Replace("\\", "/"));
+            map.SaveCellDataToFile(cells, Path.Combine("Assets/Maps/altitude/mapinfo", name + "_walk.bytes").Replace("\\", "/"));
 
-            if (!Directory.Exists("Assets/maps/altitude/walkdata"))
-                Directory.CreateDirectory("Assets/maps/altitude/walkdata");
+            if (!Directory.Exists("Assets/Maps/altitude/walkdata"))
+                Directory.CreateDirectory("Assets/Maps/altitude/walkdata");
 
             var walkData = ScriptableObject.CreateInstance<RagnarokWalkData>();
             walkData.Width = map.Width;
             walkData.Height = map.Height;
             walkData.Cells = walkCells;
 
-            AssetDatabase.CreateAsset(walkData, Path.Combine("Assets/maps/altitude/walkdata", name + "_walkdata.asset").Replace("\\", "/"));
+            AssetDatabase.CreateAsset(walkData, Path.Combine("Assets/Maps/altitude/walkdata", name + "_walkdata.asset").Replace("\\", "/"));
 
             map.WalkCellData = walkData;
 
@@ -238,20 +238,20 @@ namespace Assets.Scripts.MapEditor.Editor
             map.Width = realWidth;
             map.Height = realHeight;
 
-            if (!Directory.Exists("Assets/maps/altitude/mapinfo"))
-                Directory.CreateDirectory("Assets/maps/altitude/mapinfo");
+            if (!Directory.Exists("Assets/Maps/altitude/mapinfo"))
+                Directory.CreateDirectory("Assets/Maps/altitude/mapinfo");
 
-            map.SaveCellDataToFile(cells, Path.Combine("Assets/maps/altitude/mapinfo", basename + "_walk.bytes").Replace("\\", "/"));
+            map.SaveCellDataToFile(cells, Path.Combine("Assets/Maps/altitude/mapinfo", basename + "_walk.bytes").Replace("\\", "/"));
 
-            if (!Directory.Exists("Assets/maps/altitude/walkdata"))
-                Directory.CreateDirectory("Assets/maps/altitude/walkdata");
+            if (!Directory.Exists("Assets/Maps/altitude/walkdata"))
+                Directory.CreateDirectory("Assets/Maps/altitude/walkdata");
 
             var walkData = ScriptableObject.CreateInstance<RagnarokWalkData>();
             walkData.Width = realWidth;
             walkData.Height = realHeight;
             walkData.Cells = walkCells;
 
-            AssetDatabase.CreateAsset(walkData, Path.Combine("Assets/maps/altitude/walkdata", basename + "_walkdata.asset").Replace("\\", "/"));
+            AssetDatabase.CreateAsset(walkData, Path.Combine("Assets/Maps/altitude/walkdata", basename + "_walkdata.asset").Replace("\\", "/"));
 
             map.WalkCellData = walkData;
 

--- a/RebuildClient/Assets/Scripts/MapEditor/RoMapEditor.cs
+++ b/RebuildClient/Assets/Scripts/MapEditor/RoMapEditor.cs
@@ -397,7 +397,7 @@ namespace Assets.Scripts.MapEditor
                     w.Images = new Texture2D[32];
 
                     for (var i = 0; i < 32; i++)
-                        w.Images[i] = AssetDatabase.LoadAssetAtPath<Texture2D>($"Assets/Maps/texture/water/water{w.Type}{i:D2}.jpg");
+                        w.Images[i] = AssetDatabase.LoadAssetAtPath<Texture2D>($"Assets/Maps/Texture/Water/water{w.Type}{i:D2}.jpg");
 
                     EditorUtility.SetDirty(MapData);
                 }

--- a/RebuildClient/Assets/Scripts/Utility/TextureImportHelper.cs
+++ b/RebuildClient/Assets/Scripts/Utility/TextureImportHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -13,6 +13,9 @@ namespace Assets.Scripts
 
     public class TextureImportHelper
     {
+        private static readonly Dictionary<string, bool> FileSystemCaseSensitivityCache =
+            new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
         public static void SetTexturesReadable(List<Texture2D> textures)
         {
             var hasChanges = false;
@@ -20,13 +23,13 @@ namespace Assets.Scripts
             {
                 if (!t.isReadable)
                 {
-                    var texPath = AssetDatabase.GetAssetPath(t);
-                    var tImporter = AssetImporter.GetAtPath(texPath) as TextureImporter;
-                    if (tImporter != null)
+                    var texturePath = AssetDatabase.GetAssetPath(t);
+                    var textureImporter = AssetImporter.GetAtPath(texturePath) as TextureImporter;
+                    if (textureImporter != null)
                     {
-                        tImporter.isReadable = true;
+                        textureImporter.isReadable = true;
 
-                        AssetDatabase.ImportAsset(texPath);
+                        AssetDatabase.ImportAsset(texturePath);
                         hasChanges = true;
                     }
                 }
@@ -77,44 +80,224 @@ namespace Assets.Scripts
             return texture;
         }
         
+        private static string NormalizeTextureRelativePath(string textureName)
+        {
+            return textureName
+                .TrimStart('\\', '/')
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        private static string ResolvePathCaseInsensitive(string candidatePath)
+        {
+            candidatePath = candidatePath
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+
+            if (File.Exists(candidatePath) || Directory.Exists(candidatePath))
+                return candidatePath;
+
+            if (!IsFileSystemCaseSensitive(candidatePath))
+                return candidatePath;
+
+            var root = Path.GetPathRoot(candidatePath);
+            var current = string.IsNullOrEmpty(root) ? Directory.GetCurrentDirectory() : root;
+            var remainder = string.IsNullOrEmpty(root) ? candidatePath : candidatePath.Substring(root.Length);
+
+            foreach (var pathPart in remainder.Split(Path.DirectorySeparatorChar))
+            {
+                if (string.IsNullOrEmpty(pathPart))
+                    continue;
+
+                if (!Directory.Exists(current))
+                    return candidatePath;
+
+                var exact = Path.Combine(current, pathPart);
+                if (File.Exists(exact) || Directory.Exists(exact))
+                {
+                    current = exact;
+                    continue;
+                }
+
+                string matchingEntry = null;
+                foreach (var entry in Directory.EnumerateFileSystemEntries(current))
+                {
+                    if (string.Equals(Path.GetFileName(entry), pathPart, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchingEntry = entry;
+                        break;
+                    }
+                }
+
+                if (matchingEntry == null)
+                    return candidatePath;
+
+                current = matchingEntry;
+            }
+
+            return current;
+        }
+
+        private static bool IsFileSystemCaseSensitive(string candidatePath)
+        {
+            var probeDirectory = GetCaseSensitivityProbeDirectory(candidatePath);
+            if (string.IsNullOrWhiteSpace(probeDirectory))
+                return true;
+
+            var cacheKey = Path.GetFullPath(probeDirectory);
+
+            bool cachedIsCaseSensitive;
+            if (FileSystemCaseSensitivityCache.TryGetValue(cacheKey, out cachedIsCaseSensitive))
+                return cachedIsCaseSensitive;
+
+            var probeName = ".case-sensitivity-probe-" + Guid.NewGuid().ToString("N");
+            var lowerProbePath = Path.Combine(probeDirectory, probeName.ToLowerInvariant());
+            var upperProbePath = Path.Combine(probeDirectory, probeName.ToUpperInvariant());
+
+            try
+            {
+                File.WriteAllText(lowerProbePath, string.Empty);
+                var isCaseSensitive = !File.Exists(upperProbePath);
+                FileSystemCaseSensitivityCache[cacheKey] = isCaseSensitive;
+                return isCaseSensitive;
+            }
+            catch
+            {
+                return true;
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(lowerProbePath))
+                        File.Delete(lowerProbePath);
+
+                    if (File.Exists(upperProbePath))
+                        File.Delete(upperProbePath);
+                }
+                catch
+                {
+                    // Best-effort cleanup only.
+                }
+            }
+        }
+
+        private static string GetCaseSensitivityProbeDirectory(string candidatePath)
+        {
+            var current = Directory.Exists(candidatePath)
+                ? candidatePath
+                : Path.GetDirectoryName(candidatePath);
+
+            while (!string.IsNullOrWhiteSpace(current))
+            {
+                if (Directory.Exists(current))
+                    return current;
+
+                current = Path.GetDirectoryName(current);
+            }
+
+            return Directory.Exists(Application.temporaryCachePath)
+                ? Application.temporaryCachePath
+                : null;
+        }
+
+        private static string ResolveTexturePath(string textureName, string importPath)
+        {
+            var normalizedTextureName = NormalizeTextureRelativePath(textureName);
+
+            var candidates = new[]
+            {
+                Path.Combine(importPath, "texture", normalizedTextureName),
+                Path.Combine(importPath, normalizedTextureName),
+                importPath
+            };
+
+            foreach (var candidate in candidates)
+            {
+                var resolved = ResolvePathCaseInsensitive(candidate);
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+
+            return candidates[0];
+        }
+
+        private static string ToProjectRelativeAssetPath(string path)
+        {
+            path = path.Replace('\\', '/');
+
+            var assetsIndex = path.IndexOf("Assets/", StringComparison.Ordinal);
+            path = assetsIndex >= 0 ? path.Substring(assetsIndex) : path;
+
+            if (path.Equals("Assets/Maps", StringComparison.OrdinalIgnoreCase))
+                return "Assets/Maps";
+
+            if (path.StartsWith("Assets/Maps/", StringComparison.OrdinalIgnoreCase))
+                path = "Assets/Maps/" + path.Substring("Assets/Maps/".Length);
+
+            if (path.StartsWith("Assets/Maps/Texture/", StringComparison.OrdinalIgnoreCase))
+                path = "Assets/Maps/Texture/" + path.Substring("Assets/Maps/Texture/".Length);
+
+            return path;
+        }
+
         public static Texture2D GetOrImportTextureToProject(string textureName, string importPath, string outputPath, bool keyOnBlack = false)
         {
 
-            var texPath = Path.Combine(importPath, "texture", textureName);
+            var texturePath = ResolveTexturePath(textureName, importPath);
 
-            if (!File.Exists(texPath))
-                texPath = Path.Combine(importPath, textureName);
+            //Debug.Log(texturePath);
 
-            if (!File.Exists(texPath))
-                texPath = importPath;
-
-            //Debug.Log(texPath);
-
-            if (File.Exists(texPath))
+            if (File.Exists(texturePath))
             {
-                var bpath = Path.GetDirectoryName(textureName);
-                var fname = Path.GetFileNameWithoutExtension(textureName);
-                var texOutPath = Path.Combine(outputPath, DirectoryHelper.GetRelativeDirectory(importPath, Path.GetDirectoryName(texPath)));
-                var pngPath = Path.Combine(texOutPath, fname + ".png");
+                var textureBaseName = Path.GetFileNameWithoutExtension(NormalizeTextureRelativePath(textureName));
+                var textureOutputDirectory = Path.Combine(outputPath, DirectoryHelper.GetRelativeDirectory(importPath, Path.GetDirectoryName(texturePath)));
+                var pngPath = ToProjectRelativeAssetPath(Path.Combine(textureOutputDirectory, textureBaseName + ".png"));
                 
                 if (!File.Exists(pngPath))
                 {
-                    var tex2D = LoadTexture(texPath, keyOnBlack);
+                    var texture = LoadTexture(texturePath, keyOnBlack);
 
-                    tex2D.name = textureName;
+                    try
+                    {
+                        texture.name = Path.GetFileNameWithoutExtension(texturePath);
 
-                    PathHelper.CreateDirectoryIfNotExists(texOutPath);
+                        PathHelper.CreateDirectoryIfNotExists(Path.GetDirectoryName(pngPath));
 
-                    File.WriteAllBytes(pngPath, tex2D.EncodeToPNG());
+                        File.WriteAllBytes(pngPath, texture.EncodeToPNG());
 
-                    //Debug.Log("Png file does not exist: " + pngPath);
-
-                    AssetDatabase.Refresh();
+                        //Debug.Log("Png file does not exist: " + pngPath);
+                    }
+                    finally
+                    {
+                        if (texture != null)
+                            UnityEngine.Object.DestroyImmediate(texture);
+                    }
                 }
 
-                var texout = AssetDatabase.LoadAssetAtPath(pngPath, typeof(Texture2D)) as Texture2D;
+                var importedTexture = AssetDatabase.LoadAssetAtPath<Texture2D>(pngPath);
+                if (importedTexture == null)
+                {
+                    AssetDatabase.ImportAsset(pngPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    importedTexture = AssetDatabase.LoadAssetAtPath<Texture2D>(pngPath);
+                }
 
-                return texout;
+                if (importedTexture == null)
+                {
+                    AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+                    AssetDatabase.ImportAsset(pngPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    importedTexture = AssetDatabase.LoadAssetAtPath<Texture2D>(pngPath);
+                }
+
+                if (importedTexture == null)
+                {
+                    Debug.LogWarning($"Imported texture {textureName} from {texturePath} to {pngPath}, but Unity could not load it as Texture2D. Falling back to readable source texture for atlas packing.");
+                    var fallbackTexture = LoadTexture(texturePath, keyOnBlack);
+                    fallbackTexture.name = Path.GetFileNameWithoutExtension(texturePath);
+                    return fallbackTexture;
+                }
+
+                return importedTexture;
             }
 
             throw new Exception($"Could not find texture {textureName} in the import path {importPath}");

--- a/RebuildClient/Assets/Shaders/BillboardVerticalZDepthDirect.shader
+++ b/RebuildClient/Assets/Shaders/BillboardVerticalZDepthDirect.shader
@@ -167,7 +167,7 @@ Shader "Unlit/BillboardVerticalZDepthDirect"
             #pragma multi_compile _ BLINDEFFECT_ON
             
             #include "UnityCG.cginc"
-            #include "Billboard.cginc"
+            #include "billboard.cginc"
 
             #pragma multi_compile_instancing
             

--- a/RebuildClient/Assets/Shaders/SpriteShaderNoZTest.shader
+++ b/RebuildClient/Assets/Shaders/SpriteShaderNoZTest.shader
@@ -42,7 +42,7 @@ Shader"Ragnarok/CharacterSpriteShaderNoZTest"
 
 			#include "UnityCG.cginc"
 			#include "UnityUI.cginc"
-			#include "Billboard.cginc"
+			#include "billboard.cginc"
 
 			struct appdata_t
 			{

--- a/RebuildClient/Assets/Shaders/TestSpriteShader.shader
+++ b/RebuildClient/Assets/Shaders/TestSpriteShader.shader
@@ -81,7 +81,7 @@ Shader "Unlit/TestSpriteShader"
 
 				#include "UnityCG.cginc"
 				#include "UnityUI.cginc"
-				#include "Billboard.cginc"
+				#include "billboard.cginc"
 
 				struct appdata_t
 				{

--- a/RoRebuildServer/DataToClientUtility/Program.cs
+++ b/RoRebuildServer/DataToClientUtility/Program.cs
@@ -19,13 +19,22 @@ namespace DataToClientUtility;
 
 class Program
 {
-    private const string path = @"..\..\..\..\GameConfig\ServerData\Db\";
-    private const string warpsPath = @"..\..\..\..\GameConfig\ServerData\Script\Warps";
-    private const string npcsPath = @"..\..\..\..\GameConfig\ServerData\Script\Npcs";
-    private const string eventScriptsPath = @"..\..\..\..\GameConfig\ServerData\Script\Event";
-    private const string outPath = @"..\..\..\..\..\RebuildClient\Assets\StreamingAssets\ClientConfigGenerated\";
-    private const string outPathStreaming = @"..\..\..\..\..\RebuildClient\Assets\StreamingAssets\";
-    private const string configPath = @"..\..\..\..\..\RebuildServer\";
+    private static string FromBase(params string[] parts)
+    {
+        var combined = AppContext.BaseDirectory;
+        foreach (var part in parts)
+            combined = Path.Combine(combined, part);
+
+        return Path.GetFullPath(combined);
+    }
+
+    private static readonly string path = FromBase("..", "..", "..", "..", "GameConfig", "ServerData", "Db");
+    private static readonly string warpsPath = FromBase("..", "..", "..", "..", "GameConfig", "ServerData", "Script", "Warps");
+    private static readonly string npcsPath = FromBase("..", "..", "..", "..", "GameConfig", "ServerData", "Script", "Npcs");
+    private static readonly string eventScriptsPath = FromBase("..", "..", "..", "..", "GameConfig", "ServerData", "Script", "Event");
+    private static readonly string outPath = FromBase("..", "..", "..", "..", "..", "RebuildClient", "Assets", "StreamingAssets", "ClientConfigGenerated");
+    private static readonly string outPathStreaming = FromBase("..", "..", "..", "..", "..", "RebuildClient", "Assets", "StreamingAssets");
+    private static readonly string configPath = FromBase("..", "..", "..", "..", "..", "RebuildServer");
 
     private static List<PlayerWeaponClass>? weaponClasses;
     private static Dictionary<string, string> equipGroupDescriptions = new();


### PR DESCRIPTION
## Summary

I was trying to get the Unity client importing/running on Linux and ran into a few path-related issues that seem useful to fix for future Linux users, or anyone working on a case-sensitive filesystem.

 It includes only source/shader changes that looked generally portable rather than local workarounds

* resolves `.act` / `.spr` sibling files case-insensitively
* uses consistent `Assets/Maps` and `Assets/Models` casing in importer output paths
* normalizes model and texture paths that may come from GRF data with Windows-style separators
* makes selected data-directory path handling use normalized full paths
* fixes shader include casing for the tracked `billboard.cginc` file

I tried to keep this low-risk for Windows users: exact paths still resolve normally there, and most of the new logic only kicks in when path casing/separators would otherwise fail.