### PR TITLE
Add client data import health check

### DIFF
--- a/RebuildClient/Assets/Scripts/Editor/RagnarokClientDataImportDefinitions.cs
+++ b/RebuildClient/Assets/Scripts/Editor/RagnarokClientDataImportDefinitions.cs
@@ -1,0 +1,104 @@
+namespace Assets.Editor
+{
+    internal static class RagnarokClientDataImportDefinitions
+    {
+        internal const string MapConfigurationPath = "Assets/StreamingAssets/ClientConfigGenerated/maps.json";
+        internal const string MapSceneDirectory = "Assets/Scenes/Maps";
+        internal const string WaterSourceRelativePath = "texture/워터";
+        internal const string WaterDestinationDirectory = "Assets/Maps/Texture/Water";
+
+        internal readonly struct JobSpriteMapping
+        {
+            public readonly string SourceName;
+            public readonly string DestinationName;
+
+            public JobSpriteMapping(string sourceName, string destinationName)
+            {
+                SourceName = sourceName;
+                DestinationName = destinationName;
+            }
+        }
+
+        internal readonly struct FixedFileImport
+        {
+            public readonly string SourceRelativePath;
+            public readonly string DestinationPath;
+
+            public FixedFileImport(string sourceRelativePath, string destinationPath)
+            {
+                SourceRelativePath = sourceRelativePath;
+                DestinationPath = destinationPath;
+            }
+        }
+
+        internal readonly struct TemporaryMonsterAlias
+        {
+            public readonly string SourceSpriteName;
+            public readonly string AliasSpriteName;
+
+            public TemporaryMonsterAlias(string sourceSpriteName, string aliasSpriteName)
+            {
+                SourceSpriteName = sourceSpriteName;
+                AliasSpriteName = aliasSpriteName;
+            }
+        }
+
+        internal static readonly JobSpriteMapping[] JobSpriteMappings =
+        {
+            new JobSpriteMapping("성직자", "Acolyte"),
+            new JobSpriteMapping("궁수", "Archer"),
+            new JobSpriteMapping("마법사", "Mage"),
+            new JobSpriteMapping("상인", "Merchant"),
+            new JobSpriteMapping("초보자", "Novice"),
+            new JobSpriteMapping("검사", "Swordsman"),
+            new JobSpriteMapping("도둑", "Thief"),
+            new JobSpriteMapping("슈퍼노비스", "SuperNovice"),
+            new JobSpriteMapping("기사", "Knight"),
+            new JobSpriteMapping("위저드", "Wizard"),
+            new JobSpriteMapping("프리스트", "Priest"),
+            new JobSpriteMapping("헌터", "Hunter"),
+            new JobSpriteMapping("어세신", "Assassin"),
+            new JobSpriteMapping("제철공", "Blacksmith"),
+            new JobSpriteMapping("크루세이더", "Crusader"),
+            new JobSpriteMapping("세이지", "Sage"),
+            new JobSpriteMapping("바드", "Bard"),
+            new JobSpriteMapping("무희", "Dancer"),
+            new JobSpriteMapping("몽크", "Monk"),
+            new JobSpriteMapping("로그", "Rogue"),
+            new JobSpriteMapping("연금술사", "Alchemist"),
+            new JobSpriteMapping("운영자", "GameMaster"),
+            new JobSpriteMapping("신페코크루세이더", "PecoCrusader"),
+            new JobSpriteMapping("페코페코_기사", "PecoKnight")
+        };
+
+        internal static readonly string[] ShieldSpriteSourceNameExceptions =
+        {
+            "운영자",
+            "신페코크루세이더",
+            "페코페코_기사"
+        };
+
+        internal static readonly FixedFileImport[] MiscellaneousFiles =
+        {
+            new FixedFileImport("sprite/cursors.act", "Assets/Sprites/Misc/cursors.act"),
+            new FixedFileImport("sprite/cursors.spr", "Assets/Sprites/Misc/cursors.spr"),
+            new FixedFileImport("sprite/이팩트/emotion.act", "Assets/Sprites/Misc/emotion.act"),
+            new FixedFileImport("sprite/이팩트/emotion.spr", "Assets/Sprites/Misc/emotion.spr"),
+            new FixedFileImport("sprite/이팩트/숫자.act", "Assets/Sprites/Misc/damagenumbers.act"),
+            new FixedFileImport("sprite/이팩트/숫자.spr", "Assets/Sprites/Misc/damagenumbers.spr")
+        };
+
+        internal static readonly TemporaryMonsterAlias[] TemporaryMonsterAliases =
+        {
+            new TemporaryMonsterAlias("andre", "andre_larva"),
+            new TemporaryMonsterAlias("deniro", "deniro_larva"),
+            new TemporaryMonsterAlias("piere", "piere_larva"),
+            new TemporaryMonsterAlias("andre", "soldier_andre"),
+            new TemporaryMonsterAlias("deniro", "soldier_deniro"),
+            new TemporaryMonsterAlias("piere", "soldier_piere"),
+            new TemporaryMonsterAlias("vagabond_wolf", "were_wolf"),
+            new TemporaryMonsterAlias("frilldora", "raptice"),
+            new TemporaryMonsterAlias("poison_spore", "deathspore")
+        };
+    }
+}

--- a/RebuildClient/Assets/Scripts/Editor/RagnarokClientDataImportDefinitions.cs.meta
+++ b/RebuildClient/Assets/Scripts/Editor/RagnarokClientDataImportDefinitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c35a1bfc03b4fbf8fb84348f2c21de7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/RebuildClient/Assets/Scripts/Editor/RagnarokCopyFromRealClient.cs
+++ b/RebuildClient/Assets/Scripts/Editor/RagnarokCopyFromRealClient.cs
@@ -114,7 +114,7 @@ namespace Assets.Editor
                 RagnarokDirectory.SetDataDirectory();
 
                 dataDir = RagnarokDirectory.GetRagnarokDataDirectorySafe;
-                if (dataDir == null)
+                if (string.IsNullOrWhiteSpace(dataDir))
                     return;
             }
 
@@ -282,6 +282,11 @@ namespace Assets.Editor
             CreateTemporarySpriteIfRequired("frilldora", "raptice");
             CreateTemporarySpriteIfRequired("poison_spore", "deathspore");
 
+            RunPostCopyProcessing(openLightingManager: true);
+        }
+
+        private static void RunPostCopyProcessing(bool openLightingManager)
+        {
             AssetDatabase.Refresh();
 
             EffectStrImporter.Import(); //effects
@@ -290,13 +295,81 @@ namespace Assets.Editor
             RagnarokMapImporterWindow.ImportAllMissingMaps();
             ItemIconImporter.ImportItems();
 
-            RoLightingManagerWindow.CreateOrOpen();
+            if (openLightingManager)
+                RoLightingManagerWindow.CreateOrOpen();
         }
 
-        [MenuItem("Ragnarok/Select data to copy from client data folder", priority = 2)]
+        private class CopyFilePlan
+        {
+            public string SourcePath;
+            public string DestinationPath;
+        }
+
+        private static List<CopyFilePlan> BuildCopyFilePlan(
+            string sourceDirectory,
+            string destinationDirectory,
+            bool recursive = false,
+            bool maleFemaleSplit = false,
+            string filter = "*",
+            Func<string, string> updateFileName = null)
+        {
+            var copyFilePlan = new List<CopyFilePlan>();
+
+            if (!Directory.Exists(sourceDirectory))
+                return copyFilePlan;
+
+            var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+
+            foreach (var sourcePath in Directory.GetFiles(sourceDirectory, filter, searchOption))
+            {
+                copyFilePlan.Add(new CopyFilePlan
+                {
+                    SourcePath = sourcePath,
+                    DestinationPath = GetCopyDestinationPath(
+                        sourceDirectory,
+                        sourcePath,
+                        destinationDirectory,
+                        maleFemaleSplit,
+                        updateFileName
+                    )
+                });
+            }
+
+            return copyFilePlan;
+        }
+
+        private static string GetCopyDestinationPath(
+            string sourceDirectory,
+            string sourcePath,
+            string destinationDirectory,
+            bool maleFemaleSplit,
+            Func<string, string> updateFileName)
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, sourcePath);
+            var destinationPath = Path.Combine(destinationDirectory, relativePath);
+
+            if (maleFemaleSplit)
+            {
+                if (relativePath.Contains("_남_"))
+                    destinationPath = Path.Combine(destinationDirectory, "Male", relativePath);
+
+                if (relativePath.Contains("_여_"))
+                    destinationPath = Path.Combine(destinationDirectory, "Female", relativePath);
+            }
+
+            if (updateFileName != null)
+                destinationPath = updateFileName(destinationPath);
+
+            if (Path.GetExtension(sourcePath).Equals(".bmp", StringComparison.OrdinalIgnoreCase))
+                destinationPath = Path.ChangeExtension(destinationPath, ".png");
+
+            return destinationPath;
+        }
+
+        [MenuItem("Ragnarok/Client Data Health Check", priority = 2)]
         public static void ShowCopyClientDataWindow()
         {
-            var window = GetWindow<RagnarokCopyFromRealClientWindow>("Copy Client Data");
+            var window = GetWindow<RagnarokCopyFromRealClientWindow>("Client Data Health Check");
             window.minSize = new Vector2(450, 600);
             window.Focus();
         }
@@ -308,12 +381,493 @@ namespace Assets.Editor
                 public string Label;
                 public Action Execute;
                 public Func<bool> IsAlreadyImported;
+                public Func<ImportHealth> GetHealth;
             }
 
             private List<CopyCategory> categories;
-            private bool[] selections;
+            private List<ImportTaskState> taskStates;
             private Vector2 scrollPos;
             private string dataDir;
+
+            private CopyCategory CreateCopyCategory(
+                string label,
+                string sourceRelativePath,
+                string destinationDirectory,
+                bool recursive = false,
+                bool maleFemaleSplit = false,
+                string filter = "*",
+                Func<string, string> updateFileName = null)
+            {
+                var sourceDirectory = Path.Combine(dataDir, sourceRelativePath);
+
+                return new CopyCategory
+                {
+                    Label = label,
+                    Execute = () => CopyFolder(
+                        sourceDirectory,
+                        destinationDirectory,
+                        recursive,
+                        maleFemaleSplit,
+                        filter,
+                        updateFileName
+                    ),
+                    IsAlreadyImported = () => IsCopyFolderComplete(
+                        sourceDirectory,
+                        destinationDirectory,
+                        recursive,
+                        maleFemaleSplit,
+                        filter,
+                        updateFileName
+                    ),
+                    GetHealth = () => GetCopyFolderHealth(
+                        sourceDirectory,
+                        destinationDirectory,
+                        recursive,
+                        maleFemaleSplit,
+                        filter,
+                        updateFileName
+                    )
+                };
+            }
+
+
+
+            private class ImportHealth
+            {
+                public int Present;
+                public int Total;
+                public string UnitLabel = "files";
+                public string PresentLabel = "present";
+                public string ErrorMessage;
+                public int Missing => Math.Max(0, Total - Present);
+                public bool HasProgress => Total > 0;
+                public bool IsComplete => string.IsNullOrWhiteSpace(ErrorMessage) && Total > 0 && Missing == 0;
+
+                public string ToDisplayString()
+                {
+                    if (!string.IsNullOrWhiteSpace(ErrorMessage))
+                        return ErrorMessage;
+
+                    if (Total == 0)
+                        return $"No source {UnitLabel} found";
+
+                    return $"{Present}/{Total} {UnitLabel} {PresentLabel}, {Missing} missing";
+                }
+            }
+
+            private class ImportTaskState
+            {
+                public CopyCategory Category;
+                public bool NeedsImport;
+                public bool Selected;
+                public string Status;
+                public ImportHealth Health;
+            }
+
+            private static string UpdateJobSpriteName(string path)
+            {
+                foreach (var mapping in RagnarokClientDataImportDefinitions.JobSpriteMappings)
+                    path = path.Replace(mapping.SourceName, mapping.DestinationName);
+
+                return path.Replace("여_", "F_").Replace("남_", "M_");
+            }
+
+            private static bool ShouldImportJobSpriteMapping(
+                RagnarokClientDataImportDefinitions.JobSpriteMapping mapping,
+                string destinationRoot)
+            {
+                if (!string.Equals(destinationRoot, "Shields", StringComparison.Ordinal))
+                    return true;
+
+                return !RagnarokClientDataImportDefinitions.ShieldSpriteSourceNameExceptions.Contains(mapping.SourceName);
+            }
+
+            private static ImportHealth GetJobSpriteHealth(string dataDir, string sourceRoot, string destinationRoot)
+            {
+                var copyFilePlan = new List<CopyFilePlan>();
+
+                foreach (var mapping in RagnarokClientDataImportDefinitions.JobSpriteMappings)
+                {
+                    if (!ShouldImportJobSpriteMapping(mapping, destinationRoot))
+                        continue;
+
+                    copyFilePlan.AddRange(BuildCopyFilePlan(
+                        Path.Combine(dataDir, sourceRoot, mapping.SourceName),
+                        $"Assets/Sprites/{destinationRoot}/{mapping.DestinationName}/",
+                        maleFemaleSplit: true,
+                        updateFileName: UpdateJobSpriteName
+                    ));
+                }
+
+                return GetCopyFilePlanHealth(copyFilePlan);
+            }
+
+            private static bool IsJobSpriteImportComplete(string dataDir, string sourceRoot, string destinationRoot)
+            {
+                return GetJobSpriteHealth(dataDir, sourceRoot, destinationRoot).IsComplete;
+            }
+
+            private static void CopyJobSprites(string dataDir, string sourceRoot, string destinationRoot)
+            {
+                foreach (var mapping in RagnarokClientDataImportDefinitions.JobSpriteMappings)
+                {
+                    if (!ShouldImportJobSpriteMapping(mapping, destinationRoot))
+                        continue;
+
+                    CopyFolder(
+                        Path.Combine(dataDir, sourceRoot, mapping.SourceName),
+                        $"Assets/Sprites/{destinationRoot}/{mapping.DestinationName}/",
+                        maleFemaleSplit: true,
+                        updateFileName: UpdateJobSpriteName
+                    );
+                }
+            }
+
+            private static bool HasAnyFile(string path, string pattern, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                return Directory.Exists(path) && Directory.GetFiles(path, pattern, searchOption).Any();
+            }
+
+
+
+
+
+            private static ImportHealth GetCopyFolderHealth(
+                string sourceDirectory,
+                string destinationDirectory,
+                bool recursive = false,
+                bool maleFemaleSplit = false,
+                string filter = "*",
+                Func<string, string> updateFileName = null)
+            {
+                return GetCopyFilePlanHealth(BuildCopyFilePlan(
+                    sourceDirectory,
+                    destinationDirectory,
+                    recursive,
+                    maleFemaleSplit,
+                    filter,
+                    updateFileName
+                ));
+            }
+
+            private static ImportHealth GetCopyFilePlanHealth(IEnumerable<CopyFilePlan> copyFilePlan)
+            {
+                var health = new ImportHealth();
+
+                foreach (var copyFile in copyFilePlan)
+                {
+                    health.Total++;
+
+                    if (File.Exists(copyFile.DestinationPath))
+                        health.Present++;
+                }
+
+                return health;
+            }
+
+            private static ImportHealth GetFixedFileHealth(IEnumerable<string> destinationPaths)
+            {
+                var health = new ImportHealth();
+
+                foreach (var destinationPath in destinationPaths)
+                {
+                    health.Total++;
+
+                    if (File.Exists(destinationPath))
+                        health.Present++;
+                }
+
+                return health;
+            }
+
+            private static bool IsCopyFolderComplete(
+                string sourceDirectory,
+                string destinationDirectory,
+                bool recursive = false,
+                bool maleFemaleSplit = false,
+                string filter = "*",
+                Func<string, string> updateFileName = null)
+            {
+                return GetCopyFolderHealth(
+                    sourceDirectory,
+                    destinationDirectory,
+                    recursive,
+                    maleFemaleSplit,
+                    filter,
+                    updateFileName
+                ).IsComplete;
+            }
+
+
+
+            private static IEnumerable<string> GetMiscellaneousDestinationPaths()
+            {
+                return RagnarokClientDataImportDefinitions.MiscellaneousFiles
+                    .Select(fileImport => fileImport.DestinationPath);
+            }
+
+            private ImportHealth GetMiscellaneousFileHealth()
+            {
+                return GetFixedFileHealth(GetMiscellaneousDestinationPaths());
+            }
+
+            private bool HasMiscellaneousFiles()
+            {
+                return GetMiscellaneousFileHealth().IsComplete;
+            }
+
+            private static bool HasGeneratedEffectPrefabs()
+            {
+                return HasAnyFile("Assets/Effects/Prefabs", "*.prefab");
+            }
+
+            private static bool HasSkillEffectAtlas()
+            {
+                return File.Exists("Assets/Textures/Resources/SkillAtlas.spriteatlasv2") &&
+                       File.Exists("Assets/Textures/Import/FireBolt1.png") &&
+                       File.Exists("Assets/Textures/Import/coin_a.png") &&
+                       File.Exists("Assets/Textures/Resources/BigBang.png");
+            }
+
+            private ImportHealth GetWaterTextureHealth()
+            {
+                return GetCopyFolderHealth(
+                    Path.Combine(dataDir, RagnarokClientDataImportDefinitions.WaterSourceRelativePath),
+                    RagnarokClientDataImportDefinitions.WaterDestinationDirectory,
+                    filter: "water*.jpg"
+                );
+            }
+
+            private bool HasImportedWaterTextures()
+            {
+                return GetWaterTextureHealth().IsComplete;
+            }
+
+            [Serializable]
+            private class MapConfigurationWrapper
+            {
+                public List<MapConfigurationEntry> Items;
+            }
+
+            [Serializable]
+            private class MapConfigurationEntry
+            {
+                public string Code;
+            }
+
+            private static ImportHealth GetMapImportHealth()
+            {
+                var mapConfigurationPath = RagnarokClientDataImportDefinitions.MapConfigurationPath;
+                var mapSceneDirectory = RagnarokClientDataImportDefinitions.MapSceneDirectory;
+
+                var health = new ImportHealth { UnitLabel = "maps", PresentLabel = "imported" };
+
+                if (!File.Exists(mapConfigurationPath))
+                {
+                    health.ErrorMessage = $"Missing map configuration: {mapConfigurationPath}";
+                    return health;
+                }
+
+                try
+                {
+                    var mapConfiguration = JsonUtility.FromJson<MapConfigurationWrapper>(
+                        File.ReadAllText(mapConfigurationPath)
+                    );
+
+                    var maps = mapConfiguration?.Items ?? new List<MapConfigurationEntry>();
+                    health.Total = maps.Count;
+
+                    foreach (var map in maps)
+                    {
+                        if (string.IsNullOrWhiteSpace(map.Code))
+                            continue;
+
+                        var mapScenePath = Path.Combine(mapSceneDirectory, map.Code + ".unity")
+                            .Replace("\\", "/");
+
+                        if (File.Exists(mapScenePath))
+                            health.Present++;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    health.ErrorMessage = $"Could not read map configuration: {exception.Message}";
+                }
+
+                return health;
+            }
+
+            private static bool HasImportedMapAssets()
+            {
+                return GetMapImportHealth().IsComplete;
+            }
+
+            private static ImportHealth GetMapHealth()
+            {
+                return GetMapImportHealth();
+            }
+
+
+            private static bool HasImportedItemIcons()
+            {
+                return File.Exists("Assets/Textures/ItemAtlas.spriteatlasv2") &&
+                       HasAnyFile("Assets/Sprites/Imported/Icons/Sprites", "*.png") &&
+                       HasAnyFile("Assets/Sprites/Imported/Collections", "*.png");
+            }
+
+            private static ImportHealth GetTemporaryMonsterAliasHealth()
+            {
+                return GetFixedFileHealth(
+                    RagnarokClientDataImportDefinitions.TemporaryMonsterAliases.SelectMany(alias => new[]
+                    {
+                        $"Assets/Sprites/Monsters/{alias.AliasSpriteName}.spr",
+                        $"Assets/Sprites/Monsters/{alias.AliasSpriteName}.act"
+                    })
+                );
+            }
+
+            private static bool HasTemporaryMonsterAliases()
+            {
+                return GetTemporaryMonsterAliasHealth().IsComplete;
+            }
+
+            private static void CreateTemporaryMonsterAliases()
+            {
+                foreach (var alias in RagnarokClientDataImportDefinitions.TemporaryMonsterAliases)
+                    CreateTemporarySpriteIfRequired(alias.SourceSpriteName, alias.AliasSpriteName);
+            }
+
+            private void RunHealthCheck()
+            {
+                if (categories == null)
+                    return;
+
+                var previousSelection = taskStates == null
+                    ? new Dictionary<string, bool>()
+                    : taskStates.ToDictionary(taskState => taskState.Category.Label, taskState => taskState.Selected);
+
+                taskStates = new List<ImportTaskState>(categories.Count);
+
+                foreach (var category in categories)
+                {
+                    var taskState = new ImportTaskState
+                    {
+                        Category = category
+                    };
+
+                    try
+                    {
+                        taskState.Health = category.GetHealth?.Invoke();
+
+                        var isImported = taskState.Health != null
+                            ? taskState.Health.IsComplete
+                            : category.IsAlreadyImported();
+
+                        taskState.NeedsImport = !isImported;
+                        taskState.Status = isImported ? "OK" : "Needs import";
+
+                        taskState.Selected = previousSelection.TryGetValue(category.Label, out var wasSelected)
+                            ? taskState.NeedsImport && wasSelected
+                            : taskState.NeedsImport;
+                    }
+                    catch (Exception exception)
+                    {
+                        taskState.NeedsImport = true;
+                        taskState.Selected = previousSelection.TryGetValue(category.Label, out var wasSelected) ? wasSelected : true;
+                        taskState.Status = "Error";
+                        taskState.Health = new ImportHealth { ErrorMessage = exception.Message };
+
+                        Debug.LogError(
+                            $"[Health Check Failure] Category = '{category.Label}'\n" +
+                            $"Exception message: {exception.Message}\n" +
+                            $"Full stack trace:\n{exception}"
+                        );
+                    }
+
+                    taskStates.Add(taskState);
+                }
+
+                Repaint();
+            }
+
+
+            private void SelectMissing()
+            {
+                if (taskStates == null)
+                    return;
+
+                foreach (var taskState in taskStates)
+                    taskState.Selected = taskState.NeedsImport;
+
+                Repaint();
+            }
+
+
+            private void ClearSelection()
+            {
+                if (taskStates == null)
+                    return;
+
+                foreach (var taskState in taskStates)
+                    taskState.Selected = false;
+
+                Repaint();
+            }
+
+
+            private void ImportMissing()
+            {
+                var previousSelection = taskStates == null
+                    ? new Dictionary<string, bool>()
+                    : taskStates.ToDictionary(taskState => taskState.Category.Label, taskState => taskState.Selected);
+
+                RunHealthCheck();
+
+                if (taskStates == null)
+                    return;
+
+                foreach (var taskState in taskStates)
+                {
+                    if (previousSelection.TryGetValue(taskState.Category.Label, out var wasSelected))
+                        taskState.Selected = taskState.NeedsImport && wasSelected;
+                }
+
+                var importedTaskCount = 0;
+                var refreshedBeforePostProcess = false;
+
+                foreach (var taskState in taskStates)
+                {
+                    if (!taskState.NeedsImport || !taskState.Selected)
+                        continue;
+
+                    try
+                    {
+                        if (!refreshedBeforePostProcess &&
+                            taskState.Category.Label.StartsWith("Post-process:", StringComparison.Ordinal))
+                        {
+                            AssetDatabase.Refresh();
+                            refreshedBeforePostProcess = true;
+                        }
+
+                        taskState.Category.Execute();
+                        importedTaskCount++;
+                    }
+                    catch (Exception exception)
+                    {
+                        Debug.LogError(
+                            $"[Import Missing Failure] Category = '{taskState.Category.Label}'\n" +
+                            $"Exception message: {exception.Message}\n" +
+                            $"Full stack trace:\n{exception}"
+                        );
+                    }
+                }
+
+                AssetDatabase.Refresh();
+                RunHealthCheck();
+                Debug.Log($"Imported {importedTaskCount} selected missing client data tasks.");
+            }
+
+
 
             private void OnEnable()
             {
@@ -328,399 +882,316 @@ namespace Assets.Editor
 
                     RagnarokDirectory.SetDataDirectory();
                     dataDir = RagnarokDirectory.GetRagnarokDataDirectorySafe;
-                    if (dataDir == null)
+                    if (string.IsNullOrWhiteSpace(dataDir))
                         return;
                 }
 
                 // sanity checks
                 bool TestPath(string fileName)
                 {
-                    var full = Path.Combine(dataDir, fileName);
+                    var normalizedFileName = fileName.Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar);
+                    var full = Path.Combine(dataDir, normalizedFileName);
+
                     if (!File.Exists(full))
                     {
-                        Debug.LogError($"Invalid client data directory: missing {fileName}");
+                        Debug.LogError($"Invalid client data directory: missing {normalizedFileName}");
                         return false;
                     }
 
                     return true;
                 }
 
-                if (!TestPath("prontera.gat") || !TestPath("texture\\워터\\water000.jpg"))
+                if (!TestPath("prontera.gat") || !TestPath("texture/워터/water000.jpg"))
                     return;
 
                 // Define each copy category
                 categories = new List<CopyCategory>
                 {
-                    new CopyCategory
-                    {
-                        Label = "Sounds (WAV)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "wav/"), "Assets/Sounds/", recursive: true),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sounds") && Directory
-                                .GetFiles("Assets/Sounds", "*.wav", SearchOption.AllDirectories).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Monster Sprites",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/몬스터"), "Assets/Sprites/Monsters/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Monsters") && Directory.GetFiles("Assets/Sprites/Monsters",
-                                "*.spr", SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Headgear Sprites (Male)",
-                        Execute = () =>
-                            CopyFolder(Path.Combine(dataDir, "sprite/악세사리/남"), "Assets/Sprites/Headgear/Male/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Headgear/Male") && Directory
-                                .GetFiles("Assets/Sprites/Headgear/Male", "*.spr", SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Headgear Sprites (Female)",
-                        Execute = () =>
-                            CopyFolder(Path.Combine(dataDir, "sprite/악세사리/여"), "Assets/Sprites/Headgear/Female/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Headgear/Female") && Directory
-                                .GetFiles("Assets/Sprites/Headgear/Female", "*.spr", SearchOption.TopDirectoryOnly)
-                                .Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "NPC Sprites",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/npc"), "Assets/Sprites/Npcs/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Npcs") && Directory
-                                .GetFiles("Assets/Sprites/Npcs", "*.spr", SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Effect Sprites",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/이팩트"), "Assets/Sprites/Effects/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Effects") && Directory.GetFiles("Assets/Sprites/Effects",
-                                "*.spr", SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Head Palettes (Female)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "palette/몸"),
-                            "Assets/Sprites/Characters/HeadFemale/", recursive: false, maleFemaleSplit: false,
-                            filter: "*_여_*.pal"),
-                        IsAlreadyImported = () => Directory.GetFiles("Assets/Sprites/Characters/HeadFemale",
-                            "*_여_*.pal", SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Head Palettes (Male)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "palette/몸"),
-                            "Assets/Sprites/Characters/HeadMale/", recursive: false, maleFemaleSplit: false,
-                            filter: "*_남_*.pal"),
-                        IsAlreadyImported = () => Directory.GetFiles("Assets/Sprites/Characters/HeadMale", "*_남_*.pal",
-                            SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Character Heads (Male)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/인간족/머리통/남"),
-                            "Assets/Sprites/Characters/HeadMale/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Characters/HeadMale") && Directory
-                                .GetFiles("Assets/Sprites/Characters/HeadMale", "*.spr", SearchOption.TopDirectoryOnly)
-                                .Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Character Heads (Female)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/인간족/머리통/여"),
-                            "Assets/Sprites/Characters/HeadFemale/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Characters/HeadFemale") && Directory
-                                .GetFiles("Assets/Sprites/Characters/HeadFemale", "*.spr",
-                                    SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Character Bodies (Male)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/인간족/몸통/남"),
-                            "Assets/Sprites/Characters/BodyMale/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Characters/BodyMale") && Directory
-                                .GetFiles("Assets/Sprites/Characters/BodyMale", "*.spr", SearchOption.TopDirectoryOnly)
-                                .Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "Character Bodies (Female)",
-                        Execute = () => CopyFolder(Path.Combine(dataDir, "sprite/인간족/몸통/여"),
-                            "Assets/Sprites/Characters/BodyFemale/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Characters/BodyFemale") && Directory
-                                .GetFiles("Assets/Sprites/Characters/BodyFemale", "*.spr",
-                                    SearchOption.TopDirectoryOnly).Any()
-                    },
-                    new CopyCategory
-                    {
-                        Label = "UI Illustrations",
-                        Execute = () =>
-                            CopyFolder(Path.Combine(dataDir, "texture/유저인터페이스/illust"), "Assets/Sprites/Cutins/"),
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Cutins") && Directory.GetFiles("Assets/Sprites/Cutins",
-                                "*.bmp", SearchOption.TopDirectoryOnly).Any()
-                    },
+                    CreateCopyCategory("Sounds (WAV)", "wav/", "Assets/Sounds/", recursive: true),
+                    CreateCopyCategory("Monster Sprites", "sprite/몬스터", "Assets/Sprites/Monsters/"),
+                    CreateCopyCategory("Headgear Sprites (Male)", "sprite/악세사리/남", "Assets/Sprites/Headgear/Male/"),
+                    CreateCopyCategory("Headgear Sprites (Female)", "sprite/악세사리/여", "Assets/Sprites/Headgear/Female/"),
+                    CreateCopyCategory("NPC Sprites", "sprite/npc", "Assets/Sprites/Npcs/"),
+                    CreateCopyCategory("Effect Sprites", "sprite/이팩트", "Assets/Sprites/Effects/"),
+                    CreateCopyCategory("Head Palettes (Female)", "palette/몸", "Assets/Sprites/Characters/HeadFemale/", filter: "*_여_*.pal"),
+                    CreateCopyCategory("Head Palettes (Male)", "palette/몸", "Assets/Sprites/Characters/HeadMale/", filter: "*_남_*.pal"),
+                    CreateCopyCategory("Character Heads (Male)", "sprite/인간족/머리통/남", "Assets/Sprites/Characters/HeadMale/"),
+                    CreateCopyCategory("Character Heads (Female)", "sprite/인간족/머리통/여", "Assets/Sprites/Characters/HeadFemale/"),
+                    CreateCopyCategory("Character Bodies (Male)", "sprite/인간족/몸통/남", "Assets/Sprites/Characters/BodyMale/"),
+                    CreateCopyCategory("Character Bodies (Female)", "sprite/인간족/몸통/여", "Assets/Sprites/Characters/BodyFemale/"),
+                    CreateCopyCategory("UI Illustrations", "texture/유저인터페이스/illust", "Assets/Sprites/Cutins/"),
                     new CopyCategory
                     {
                         Label = "Weapon Sprites (All Classes)",
-                        Execute = () =>
-                        {
-                            var jobs = new[]
-                            {
-                                "성직자", "궁수", "마법사", "상인", "초보자", "검사", "도둑", "슈퍼노비스",
-                                "기사", "위저드", "프리스트", "헌터", "어세신", "제철공", "크루세이더", "세이지",
-                                "바드", "무희", "몽크", "로그", "연금술사", "운영자", "신페코크루세이더", "페코페코_기사"
-                            };
-                            var outputs = new[]
-                            {
-                                "Acolyte", "Archer", "Mage", "Merchant", "Novice", "Swordsman", "Thief", "SuperNovice",
-                                "Knight", "Wizard", "Priest", "Hunter", "Assassin", "Blacksmith", "Crusader", "Sage",
-                                "Bard", "Dancer", "Monk", "Rogue", "Alchemist", "GameMaster", "PecoCrusader", "PecoKnight"
-                            };
-                            for (int i = 0; i < jobs.Length; i++)
-                                CopyFolder(Path.Combine(dataDir, $"sprite/인간족/{jobs[i]}/"),
-                                    $"Assets/Sprites/Weapons/{outputs[i]}/", false, true, "*",
-                                    (p) =>
-                                    {
-                                        for(var j = 0; j < jobs.Length; j++)
-                                            p = p.Replace(jobs[j], outputs[j]);
-                                        return p.Replace("여_", "F_").Replace("남_", "M_");
-                                    });
-                        },
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Weapons") &&
-                            Directory.GetDirectories("Assets/Sprites/Weapons").Any()
+                        Execute = () => CopyJobSprites(dataDir, "sprite/인간족", "Weapons"),
+                        IsAlreadyImported = () => IsJobSpriteImportComplete(dataDir, "sprite/인간족", "Weapons"),
+                        GetHealth = () => GetJobSpriteHealth(dataDir, "sprite/인간족", "Weapons")
                     },
                     new CopyCategory
                     {
                         Label = "Shield Sprites (All Classes)",
-                        Execute = () =>
-                        {
-                            var jobs = new[]
-                            {
-                                "성직자", "궁수", "마법사", "상인", "초보자", "검사", "도둑", "슈퍼노비스",
-                                "기사", "위저드", "프리스트", "헌터", "어세신", "제철공", "크루세이더", "세이지",
-                                "바드", "무희", "몽크", "로그", "연금술사", "운영자", "신페코크루세이더", "페코페코_기사"
-                            };
-                            var outputs = new[]
-                            {
-                                "Acolyte", "Archer", "Mage", "Merchant", "Novice", "Swordsman", "Thief", "SuperNovice",
-                                "Knight", "Wizard", "Priest", "Hunter", "Assassin", "Blacksmith", "Crusader", "Sage",
-                                "Bard", "Dancer", "Monk", "Rogue", "Alchemist", "GameMaster", "PecoCrusader", "PecoKnight"
-                            };
-                            for (int i = 0; i < jobs.Length; i++)
-                                CopyFolder(Path.Combine(dataDir, $"sprite/방패/{jobs[i]}/"),
-                                    $"Assets/Sprites/Shields/{outputs[i]}/", false, true, "*", (p) =>
-                                    {
-                                        for(var j = 0; j < jobs.Length; j++)
-                                            p = p.Replace(jobs[j], outputs[j]);
-                                        return p.Replace("여_", "F_").Replace("남_", "M_");
-                                    });
-                        },
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Shields") &&
-                            Directory.GetDirectories("Assets/Sprites/Shields").Any()
+                        Execute = () => CopyJobSprites(dataDir, "sprite/방패", "Shields"),
+                        IsAlreadyImported = () => IsJobSpriteImportComplete(dataDir, "sprite/방패", "Shields"),
+                        GetHealth = () => GetJobSpriteHealth(dataDir, "sprite/방패", "Shields")
                     },
                     new CopyCategory
                     {
                         Label = "Miscellaneous Files (Cursors, Emotions, Damagenumbers)",
                         Execute = () =>
                         {
-                            CopySingleFile(Path.Combine(dataDir, "sprite/cursors.act"), "Assets/Sprites/Misc/");
-                            CopySingleFile(Path.Combine(dataDir, "sprite/cursors.spr"), "Assets/Sprites/Misc/");
-                            CopySingleFile(Path.Combine(dataDir, "sprite/이팩트/emotion.act"), "Assets/Sprites/Misc/");
-                            CopySingleFile(Path.Combine(dataDir, "sprite/이팩트/emotion.spr"), "Assets/Sprites/Misc/");
-                            CopySingleFile(Path.Combine(dataDir, "sprite/이팩트/숫자.act"),
-                                "Assets/Sprites/Misc/damagenumbers.act");
-                            CopySingleFile(Path.Combine(dataDir, "sprite/이팩트/숫자.spr"),
-                                "Assets/Sprites/Misc/damagenumbers.spr");
+                            foreach (var fileImport in RagnarokClientDataImportDefinitions.MiscellaneousFiles)
+                            {
+                                CopySingleFile(
+                                    Path.Combine(dataDir, fileImport.SourceRelativePath),
+                                    fileImport.DestinationPath
+                                );
+                            }
                         },
-                        IsAlreadyImported = () =>
-                            Directory.Exists("Assets/Sprites/Misc") &&
-                            Directory.GetFiles("Assets/Sprites/Misc", "*.spr").Any()
+                        IsAlreadyImported = HasMiscellaneousFiles,
+                        GetHealth = GetMiscellaneousFileHealth
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Monster Sprite Aliases",
+                        Execute = CreateTemporaryMonsterAliases,
+                        IsAlreadyImported = HasTemporaryMonsterAliases,
+                        GetHealth = GetTemporaryMonsterAliasHealth
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Effect Prefabs",
+                        Execute = EffectStrImporter.Import,
+                        IsAlreadyImported = HasGeneratedEffectPrefabs
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Skill Effect Atlas",
+                        Execute = EffectStrImporter.ImportEffectTextures,
+                        IsAlreadyImported = HasSkillEffectAtlas
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Water Textures",
+                        Execute = RagnarokMapImporterWindow.ImportWater,
+                        IsAlreadyImported = HasImportedWaterTextures,
+                        GetHealth = GetWaterTextureHealth
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Missing Maps",
+                        Execute = RagnarokMapImporterWindow.ImportAllMissingMaps,
+                        IsAlreadyImported = HasImportedMapAssets,
+                        GetHealth = GetMapHealth
+                    },
+                    new CopyCategory
+                    {
+                        Label = "Post-process: Skill and Item Icons",
+                        Execute = ItemIconImporter.ImportItems,
+                        IsAlreadyImported = HasImportedItemIcons
                     }
                 };
 
-                // Initialize selections based on whether already imported
-                selections = categories.Select(cat => !cat.IsAlreadyImported()).ToArray();
+                RunHealthCheck();
             }
+
+
+
+            private static readonly Color HealthBarBackground = new Color(0.15f, 0.15f, 0.15f, 1f);
+            private static readonly Color HealthBarPresent = new Color(0.20f, 0.62f, 0.32f, 1f);
+            private static readonly Color HealthBarMissing = new Color(0.82f, 0.55f, 0.16f, 1f);
+
+            private static GUIStyle _healthBarTextStyle;
+
+            private static GUIStyle HealthBarTextStyle
+            {
+                get
+                {
+                    if (_healthBarTextStyle != null)
+                        return _healthBarTextStyle;
+
+                    _healthBarTextStyle = new GUIStyle(EditorStyles.centeredGreyMiniLabel)
+                    {
+                        alignment = TextAnchor.MiddleCenter,
+                        fontStyle = FontStyle.Bold
+                    };
+
+                    _healthBarTextStyle.normal.textColor = Color.white;
+                    return _healthBarTextStyle;
+                }
+            }
+
+            private static void DrawHealthProgressBar(ImportHealth health)
+            {
+                if (health == null || !health.HasProgress)
+                    return;
+
+                var presentRatio = Mathf.Clamp01((float)health.Present / health.Total);
+                var missingRatio = Mathf.Clamp01((float)health.Missing / health.Total);
+
+                var rect = GUILayoutUtility.GetRect(18f, 14f, GUILayout.ExpandWidth(true));
+
+                EditorGUI.DrawRect(rect, HealthBarBackground);
+
+                if (presentRatio > 0f)
+                {
+                    var presentRect = new Rect(rect.x, rect.y, rect.width * presentRatio, rect.height);
+                    EditorGUI.DrawRect(presentRect, HealthBarPresent);
+                }
+
+                if (missingRatio > 0f)
+                {
+                    var missingRect = new Rect(rect.x + rect.width * presentRatio, rect.y, rect.width * missingRatio, rect.height);
+                    EditorGUI.DrawRect(missingRect, HealthBarMissing);
+                }
+
+                var importedLabel = string.IsNullOrWhiteSpace(health.PresentLabel)
+                    ? "present"
+                    : health.PresentLabel;
+
+                var label = $"{Mathf.RoundToInt(presentRatio * 100f)}% {importedLabel} / {Mathf.RoundToInt(missingRatio * 100f)}% missing";
+                GUI.Label(rect, label, HealthBarTextStyle);
+            }
+
 
             private void OnGUI()
             {
-                EditorGUILayout.LabelField("Select data to import:", EditorStyles.boldLabel);
-                EditorGUILayout.Space();
+                const string postProcessPrefix = "Post-process: ";
 
-                EditorGUILayout.BeginHorizontal();
-                if (GUILayout.Button("Select All", GUILayout.Height(20)))
-                    for (int i = 0; i < selections.Length; i++)
-                        selections[i] = true;
-                if (GUILayout.Button("Unselect All", GUILayout.Height(20)))
-                    for (int i = 0; i < selections.Length; i++)
-                        selections[i] = false;
-                EditorGUILayout.EndHorizontal();
-                EditorGUILayout.Space();
-
-                scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
-                for (int i = 0; i < categories.Count; i++)
-                {
-                    selections[i] = EditorGUILayout.ToggleLeft(categories[i].Label, selections[i]);
-                }
-
-                EditorGUILayout.EndScrollView();
+                EditorGUILayout.LabelField("Client Data Import Health Check", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField($"Data directory: {dataDir ?? "(not set)"}", EditorStyles.miniLabel);
                 EditorGUILayout.Space();
 
                 EditorGUILayout.HelpBox(
-                    "Before you continue, you will need to specify a directory containing the contents of an extracted data.grf. " +
-                    "For this import process to work correctly, the files will need to have been extracted with the right locale and working Korean file names.",
-                    MessageType.Warning
+                    "Scan the imported client data and generated Unity assets. " +
+                    "Select the rows you want, then import the selected missing tasks.",
+                    MessageType.Info
                 );
 
-                if (GUILayout.Button("Copy Selected Data", GUILayout.Height(30)))
+                if (categories == null)
                 {
-                    int count = 0;
-                    for (int i = 0; i < categories.Count; i++)
+                    EditorGUILayout.HelpBox(
+                        $"Could not initialize import tasks.\n\nCurrent data directory: {dataDir ?? "(not set)"}",
+                        MessageType.Error
+                    );
+
+                    if (GUILayout.Button("Set Data Directory", GUILayout.Height(28)))
                     {
-                        if (!selections[i]) continue;
-                        try
-                        {
-                            categories[i].Execute();
-                            count++;
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.LogError(
-                                $"[Copy Failure] Category = '{categories[i].Label}'\n" +
-                                $"Exception message: {ex.Message}\n" +
-                                $"Full stack trace:\n{ex}"
-                            );
-                        }
+                        RagnarokDirectory.SetDataDirectory();
+                        OnEnable();
                     }
 
-                    AssetDatabase.Refresh();
-                    Debug.Log($"Copied {count} categories.");
+                    return;
                 }
+
+                var completeTaskCount = taskStates == null ? 0 : taskStates.Count(taskState => !taskState.NeedsImport);
+                var missingTaskCount = taskStates == null ? 0 : taskStates.Count(taskState => taskState.NeedsImport);
+                var selectedTaskCount = taskStates == null ? 0 : taskStates.Count(taskState => taskState.Selected);
+                var totalTaskCount = categories.Count;
+
+                if (GUILayout.Button("Run Health Check", GUILayout.Height(32)))
+                    RunHealthCheck();
+
+                EditorGUILayout.Space();
+
+                var summaryType = missingTaskCount == 0 ? MessageType.Info : MessageType.Warning;
+                EditorGUILayout.HelpBox(
+                    $"{completeTaskCount}/{totalTaskCount} tasks OK. {missingTaskCount} task(s) need import. {selectedTaskCount} selected.",
+                    summaryType
+                );
+
+                scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
+
+                var shownRawHeader = false;
+                var shownPostHeader = false;
+
+                for (var i = 0; i < categories.Count; i++)
+                {
+                    var taskState = taskStates != null && i < taskStates.Count ? taskStates[i] : null;
+                    var category = taskState?.Category ?? categories[i];
+                    var isPostProcess = category.Label.StartsWith(postProcessPrefix, StringComparison.Ordinal);
+
+                    if (!isPostProcess && !shownRawHeader)
+                    {
+                        EditorGUILayout.Space();
+                        EditorGUILayout.LabelField("Raw client data", EditorStyles.boldLabel);
+                        shownRawHeader = true;
+                    }
+
+                    if (isPostProcess && !shownPostHeader)
+                    {
+                        EditorGUILayout.Space();
+                        EditorGUILayout.LabelField("Generated assets / post-processing", EditorStyles.boldLabel);
+                        shownPostHeader = true;
+                    }
+
+                    var status = taskState?.Status ?? "Not checked";
+                    var statusLabel = status == "OK"
+                        ? "OK"
+                        : status == "Error"
+                            ? "ERROR"
+                            : "NEEDS IMPORT";
+
+                    var taskLabel = isPostProcess
+                        ? category.Label.Substring(postProcessPrefix.Length)
+                        : category.Label;
+
+                    var canSelect = taskState != null && taskState.NeedsImport;
+                    var isSelected = taskState != null && taskState.Selected;
+
+                    EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
+
+                    EditorGUI.BeginDisabledGroup(!canSelect);
+                    var newSelected = EditorGUILayout.Toggle(isSelected, GUILayout.Width(18));
+                    EditorGUI.EndDisabledGroup();
+
+                    if (canSelect)
+                        taskState.Selected = newSelected;
+
+                    EditorGUILayout.LabelField(statusLabel, EditorStyles.miniBoldLabel, GUILayout.Width(105));
+
+                    EditorGUILayout.BeginVertical();
+                    EditorGUILayout.LabelField(taskLabel);
+
+                    var healthDetail = taskState?.Health?.ToDisplayString();
+                    if (!string.IsNullOrWhiteSpace(healthDetail))
+                    {
+                        EditorGUILayout.LabelField(healthDetail, EditorStyles.miniLabel);
+                        DrawHealthProgressBar(taskState.Health);
+                    }
+
+                    EditorGUILayout.EndVertical();
+
+                    EditorGUILayout.EndHorizontal();
+                }
+
+                EditorGUILayout.EndScrollView();
+
+                EditorGUILayout.Space();
+                EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+                EditorGUILayout.LabelField("Selection actions", EditorStyles.boldLabel);
+                EditorGUILayout.BeginHorizontal();
+
+                if (GUILayout.Button("Select Missing", GUILayout.Height(30)))
+                    SelectMissing();
+
+                if (GUILayout.Button("Clear Selection", GUILayout.Height(30)))
+                    ClearSelection();
+
+                GUI.enabled = selectedTaskCount > 0;
+                if (GUILayout.Button($"Import Selected ({selectedTaskCount})", GUILayout.Height(30)))
+                    ImportMissing();
+                GUI.enabled = true;
+
+                EditorGUILayout.EndHorizontal();
+                EditorGUILayout.EndVertical();
             }
+
+
 
             // Reuse copy helpers from original
-            private static bool CopyFolder(string src, string dest, bool recursive = false,
-                bool maleFemaleSplit = false, string filter = "*", Func<string, string> updateFileName = null)
-            {
-                if (!Directory.Exists(src))
-                {
-                    Debug.LogError($"CopyFolder: source directory not found: {src}");
-                    return false;
-                }
 
-                var opt = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-                var files = Directory.GetFiles(src, filter, opt);
-                if (files.Length == 0)
-                {
-                    Debug.LogWarning($"CopyFolder: no files in '{src}' matching '{filter}'");
-                    return false;
-                }
-
-                foreach (var path in Directory.GetFiles(src, filter, opt))
-                {
-                    var rel = Path.GetRelativePath(src, path);
-                    var destPath = Path.Combine(dest, rel);
-                    Debug.Log($"CopyFolder: {path} → {destPath}");
-                    if (maleFemaleSplit)
-                    {
-                        if (rel.Contains("_남_"))
-                            destPath = Path.Combine(dest, "Male", rel);
-                        if (rel.Contains("_여_")) destPath = Path.Combine(dest, "Female", rel);
-                    }
-
-                    if (updateFileName != null) destPath = updateFileName(destPath);
-                    var dir = Path.GetDirectoryName(destPath);
-                    if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-                    var ext = Path.GetExtension(path);
-                    if (ext.Equals(".bmp", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var tex = TextureImportHelper.LoadTexture(path);
-                        TextureImportHelper.SaveAndUpdateTexture(tex, destPath.Replace(".bmp", ".png"), ti =>
-                        {
-                            ti.textureType = TextureImporterType.Sprite;
-                            ti.spriteImportMode = SpriteImportMode.Single;
-                            ti.crunchedCompression = false;
-                            ti.textureCompression = TextureImporterCompression.CompressedHQ;
-                        });
-                    }
-                    else
-                    {
-                        if (!File.Exists(destPath))
-                            File.Copy(path, destPath, true);
-                    }
-                }
-
-                return true;
-            }
-
-            private static void CopySingleFile(string src, string dest)
-            {
-                Debug.Log($"[CopySingleFile] Attempting to copy:\n    src = {src}\n    dest = {dest}");
-                
-                string destPath;
-                bool looksLikeFolder = dest.EndsWith("/") || dest.EndsWith("\\") || Directory.Exists(dest);
-                if (looksLikeFolder && (dest.StartsWith("Assets/") || dest.StartsWith("Assets\\")))
-                {
-                    string folder = dest.TrimEnd('\\', '/');
-                    
-                    string assetsSubpath = folder.Substring("Assets/".Length);
-                    destPath = Path.Combine(Application.dataPath, assetsSubpath);
-                    
-                    var fileName = Path.GetFileName(src);
-                    destPath = Path.Combine(destPath, fileName);
-                }
-                else if (looksLikeFolder)
-                {
-                    string folder = dest.TrimEnd('\\', '/');
-                    var fileName = Path.GetFileName(src);
-                    destPath = Path.Combine(folder, fileName);
-                }
-                else
-                {
-                    destPath = dest;
-                }
-
-                var parentDir = Path.GetDirectoryName(destPath);
-                if (string.IsNullOrEmpty(parentDir))
-                {
-                    Debug.LogError($"[CopySingleFile] Invalid destination: {destPath}");
-                    return;
-                }
-                
-                if (!Directory.Exists(parentDir))
-                {
-                    Debug.Log($"[CopySingleFile] Creating directory: {parentDir}");
-                    Directory.CreateDirectory(parentDir);
-                }
-                
-                if (!File.Exists(src))
-                {
-                    Debug.LogError($"[CopySingleFile] Source not found: {src}");
-                    return;
-                }
-                
-                try
-                {
-                    File.Copy(src, destPath, overwrite: true);
-                    Debug.Log($"[CopySingleFile] Successfully copied {src} → {destPath}");
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogError($"[CopySingleFile] Failed to copy {src} → {destPath}\nException: {ex}");
-                }
-            }
         }
 
         private static void CreateTemporarySpriteIfRequired(string dummySpriteName, string spriteName)
@@ -734,110 +1205,111 @@ namespace Assets.Editor
             CopySingleFile(Path.Combine(dataDir, $"sprite/몬스터/{dummySpriteName}.act"), destActPath);
         }
 
-        private static void CopySingleFile(string src, string dest)
+        private static void CopySingleFile(string sourcePath, string destinationPath)
         {
-            Debug.Log($"[CopySingleFile] Attempting to copy:\n    src = {src}\n    dest = {dest}");
+            Debug.Log($"[CopySingleFile] Attempting to copy:\n    sourcePath = {sourcePath}\n    destinationPath = {destinationPath}");
 
-            string destPath = dest;
-            bool looksLikeFolder = dest.EndsWith("/") || dest.EndsWith("\\") || Directory.Exists(dest);
-            if (looksLikeFolder)
+            var resolvedDestinationPath = destinationPath;
+            var destinationLooksLikeFolder = destinationPath.EndsWith("/") ||
+                                             destinationPath.EndsWith("\\") ||
+                                             Directory.Exists(destinationPath);
+
+            if (destinationLooksLikeFolder)
             {
-                string folder = dest.TrimEnd('\\', '/');
-                var fileName = Path.GetFileName(src);
-                destPath = Path.Combine(folder, fileName);
+                var destinationFolder = destinationPath.TrimEnd('\\', '/');
+                var sourceFileName = Path.GetFileName(sourcePath);
+                resolvedDestinationPath = Path.Combine(destinationFolder, sourceFileName);
             }
 
-            var parentDir = Path.GetDirectoryName(destPath);
-            if (string.IsNullOrEmpty(parentDir))
+            var parentDirectory = Path.GetDirectoryName(resolvedDestinationPath);
+            if (string.IsNullOrEmpty(parentDirectory))
             {
-                Debug.LogError($"[CopySingleFile] Invalid destination: {destPath}");
+                Debug.LogError($"[CopySingleFile] Invalid destination: {resolvedDestinationPath}");
                 return;
             }
 
-            if (!Directory.Exists(parentDir))
+            if (!Directory.Exists(parentDirectory))
             {
-                Debug.Log($"[CopySingleFile] Creating directory: {parentDir}");
-                Directory.CreateDirectory(parentDir);
+                Debug.Log($"[CopySingleFile] Creating directory: {parentDirectory}");
+                Directory.CreateDirectory(parentDirectory);
             }
 
-            if (!File.Exists(src))
+            if (!File.Exists(sourcePath))
             {
-                Debug.LogError($"[CopySingleFile] Source not found: {src}");
+                Debug.LogError($"[CopySingleFile] Source not found: {sourcePath}");
                 return;
             }
 
             try
             {
-                File.Copy(src, destPath, overwrite: true);
-                Debug.Log($"[CopySingleFile] Successfully copied {src} → {destPath}");
+                File.Copy(sourcePath, resolvedDestinationPath, overwrite: true);
+                Debug.Log($"[CopySingleFile] Successfully copied {sourcePath} → {resolvedDestinationPath}");
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                Debug.LogError($"[CopySingleFile] Failed to copy {src} → {destPath}\nException: {ex}");
+                Debug.LogError($"[CopySingleFile] Failed to copy {sourcePath} → {resolvedDestinationPath}\nException: {exception}");
             }
         }
 
-        private static bool CopyFolder(string src, string dest, bool recursive = false, bool maleFemaleSplit = false,
+
+        private static bool CopyFolder(
+            string sourceDirectory,
+            string destinationDirectory,
+            bool recursive = false,
+            bool maleFemaleSplit = false,
             string filter = "*",
             Func<string, string> updateFileName = null)
         {
-            var opt = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-
-            var hasFiles = false;
-
-            if (!Directory.Exists(dest))
-                Directory.CreateDirectory(dest);
-
-            foreach (var path in Directory.GetFiles(src, filter, opt))
+            if (!Directory.Exists(sourceDirectory))
             {
-                var rel = Path.GetRelativePath(src, path);
-                var destPath = Path.Combine(dest, rel);
+                Debug.LogError($"CopyFolder: source directory not found: {sourceDirectory}");
+                return false;
+            }
 
-                hasFiles = true;
+            var copyFilePlan = BuildCopyFilePlan(
+                sourceDirectory,
+                destinationDirectory,
+                recursive,
+                maleFemaleSplit,
+                filter,
+                updateFileName
+            );
 
-                if (maleFemaleSplit)
+            if (copyFilePlan.Count == 0)
+            {
+                Debug.LogWarning($"CopyFolder: no files in '{sourceDirectory}' matching '{filter}'");
+                return false;
+            }
+
+            foreach (var copyFile in copyFilePlan)
+            {
+                var destinationParentDirectory = Path.GetDirectoryName(copyFile.DestinationPath);
+                if (!string.IsNullOrWhiteSpace(destinationParentDirectory) &&
+                    !Directory.Exists(destinationParentDirectory))
                 {
-                    if (rel.Contains("_남_"))
-                        destPath = Path.Combine(dest, "Male/", rel);
-                    if (rel.Contains("_여_"))
-                        destPath = Path.Combine(dest, "Female/", rel);
+                    Directory.CreateDirectory(destinationParentDirectory);
                 }
 
-                if (File.Exists(destPath.Replace(".bmp", ".png")))
-                    continue;
-
-                if (updateFileName != null)
-                    destPath = updateFileName(destPath);
-
-                var outDir = Path.GetDirectoryName(destPath);
-                if (!Directory.Exists(outDir))
-                    Directory.CreateDirectory(outDir);
-
-                var ext = Path.GetExtension(path);
-                var fName = Path.GetFileName(path);
-
-                if (ext == ".bmp")
+                if (Path.GetExtension(copyFile.SourcePath).Equals(".bmp", StringComparison.OrdinalIgnoreCase))
                 {
-                    var tex = TextureImportHelper.LoadTexture(path);
-                    TextureImportHelper.SaveAndUpdateTexture(tex, destPath.Replace(".bmp", ".png"), ti =>
+                    var texture = TextureImportHelper.LoadTexture(copyFile.SourcePath);
+                    TextureImportHelper.SaveAndUpdateTexture(texture, copyFile.DestinationPath, textureImporter =>
                     {
-                        ti.textureType = TextureImporterType.Sprite;
-                        ti.spriteImportMode = SpriteImportMode.Single;
-                        ti.crunchedCompression = false;
-                        ti.textureCompression = TextureImporterCompression.CompressedHQ;
+                        textureImporter.textureType = TextureImporterType.Sprite;
+                        textureImporter.spriteImportMode = SpriteImportMode.Single;
+                        textureImporter.crunchedCompression = false;
+                        textureImporter.textureCompression = TextureImporterCompression.CompressedHQ;
                     });
-                    //TextureImportHelper.GetOrImportTextureToProject(fName, path, destPath);
                 }
-                else
+                else if (!File.Exists(copyFile.DestinationPath))
                 {
-                    if (!File.Exists(destPath))
-                        File.Copy(path, destPath, false);
+                    File.Copy(copyFile.SourcePath, copyFile.DestinationPath, true);
                 }
             }
 
-            AssetDatabase.Refresh();
-
-            return hasFiles;
+            return true;
         }
+
+
     }
 }


### PR DESCRIPTION
## Summary

Adds a secondary **Client Data Import Health Check** window for the Ragnarok client data importer.

This window scans the configured extracted Ragnarok data directory and the current Unity project assets, then shows which import tasks are already complete and which ones still need work. Users can select missing tasks and import only what is needed instead of blindly rerunning full category imports.

## What changed

- Adds `Ragnarok/Client Data Health Check`
- Shows imported/missing progress for many categories
- Allows selecting rows and importing selected/missing tasks
- Reuses existing import/copy logic where possible
- Extracts import mapping data into `RagnarokClientDataImportDefinitions`
- Keeps the existing full copy/import flow intact

## Limitations
- This PR is already long enough (+942 -378) so I couldn't implement health bars for every single category otherwise the lines changed could would just be way too big. I have tried to prioritize what is most important, applying the pareto principle.

<img width="891" height="707" alt="image" src="https://github.com/user-attachments/assets/72706b34-8252-443c-a8f2-c6980100ab0f" />

<img width="891" height="707" alt="image" src="https://github.com/user-attachments/assets/7425f3c4-5908-442f-b509-8eadb7333d89" />


## Validation

Tested against:

- a fresh/partial project
- a live imported project
- a friend test branch checkout

The live imported project showed `20/22` tasks OK, with only monster aliases and missing maps still requiring import.

## Out of scope

- Automatic Addressables update
- Full JSON-derived progress for Effect Prefabs / Skill and Item Icons
- Replacing the original importer